### PR TITLE
Ae/machines/template

### DIFF
--- a/clusterctl/examples/ssh/machines.yaml.template
+++ b/clusterctl/examples/ssh/machines.yaml.template
@@ -2,7 +2,7 @@ items:
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
-    generateName: ssh-controlplane-0
+    generateName: ssh-controlplane-
     labels:
       set: controlplane
   spec:
@@ -24,10 +24,12 @@ items:
     versions:
       kubelet: 1.10.1
       controlPlane: 1.10.1
+    roles:
+    - Master
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
-    generateName: ssh-node-0
+    generateName: ssh-node-
     labels:
       set: node
   spec:
@@ -48,3 +50,5 @@ items:
     versions:
       kubelet: 1.10.1
       controlPlane: 1.10.1
+    roles:
+    - Node

--- a/clusterctl/examples/ssh/machines.yaml.template
+++ b/clusterctl/examples/ssh/machines.yaml.template
@@ -26,6 +26,7 @@ items:
       controlPlane: 1.10.1
     roles:
     - Master
+    - Etcd
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:


### PR DESCRIPTION
Added roles again to the machines templates at the same level as version. The clusterctl requires this to determine what roles each machine is as part of the process of starting controllers.