### PR TITLE
Document key generation step

### DIFF
--- a/clusterctl/examples/ssh/README.md
+++ b/clusterctl/examples/ssh/README.md
@@ -7,7 +7,17 @@
 For convenience, a generation script which populates templates based on openstack cloud provider
 configuration is provided.
 
-1. Run the generation script.
+1. Generate a Cluster Private Key.
+
+Store the key in a file reserved for this cluster.
+
+2. Set key as env var.
+```
+
+export CLUSTER_PRIVATE_KEY_PLAIN=$(cat /path/to/ClusterPrivateKey)
+```
+
+3. Run the generation script.
 ```
 ./generate-yaml.sh
 ```

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -48,7 +48,8 @@ fi
 # TODO Fill out the generation pieces as we need them.
 
 if [ -z ${CLUSTER_PRIVATE_KEY_PLAIN+x} ]; then
-    echo "Please enter a valid Cluster Private Key"
+    echo "Please generate a valid Cluster Private Key. Then run:"
+    echo "export CLUSTER_PRIVATE_KEY_PLAIN=$(cat `path/to/private/key/file`)"
     exit 1
 fi
 

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -48,8 +48,7 @@ fi
 # TODO Fill out the generation pieces as we need them.
 
 if [ -z ${CLUSTER_PRIVATE_KEY_PLAIN+x} ]; then
-    echo "Please generate a valid Cluster Private Key. Then run:"
-    echo "export CLUSTER_PRIVATE_KEY_PLAIN=$(cat `path/to/private/key/file`)"
+    echo "Please generate a valid Cluster Private Key and export the key file contents to CLUSTER_PRIVATE_KEY_PLAIN."
     exit 1
 fi
 


### PR DESCRIPTION
The generate script has a key in it. It needs to be set as an env var. This pull request adds help text and documentation reflecting this step.