### PR TITLE
Fix readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ depend:
 	dep version || go get -u github.com/golang/dep/cmd/dep
 	dep ensure
 
-depend-update: work
+depend-update: 
 	dep ensure -update
 
 generate: gendeepcopy

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Imports in the code refer to `sigs.k8s.io/cluster-api*` even though this
 repository lives under the `samsung-cnct` GitHub organization. For Go dependencies to be built correctly with `dep`, place this repository in your $GOPATH as follows:
 
 ```bash
-go get github.com/samsung-cnct/cluster-api-provider-ssh
 mkdir -p $GOPATH/src/sigs.k8s.io/
-mv $GOPATH/src/github.com/samsung-cnct/cluster-api-provider-ssh $GOPATH/src/sigs.k8s.io/
+git clone https://github.com/samsung-cnct/cluster-api-provider-ssh.git $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
+cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 make depend
 make
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ repository lives under the `samsung-cnct` GitHub organization. For Go dependenci
 mkdir -p $GOPATH/src/sigs.k8s.io/
 git clone https://github.com/samsung-cnct/cluster-api-provider-ssh.git $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
-make depend
+make depend-update
+
 make
 ```
 


### PR DESCRIPTION
* Get the git tree to the correct path
Changed the "obtaining the code" section to use git clone as go get
won't get a tree when the root of that tree has no "*.go" files.

* Use depend-update in case the GOPATH has old dependencies
If the GOPATH has old dependencies, "Solving failures" may happen as
those old dependencies will try to be used and may not have the needed
functions. Use the latest dependencies to prevent this problem.