### PR TITLE
Specify bash explicitly in shebang.

### DIFF
--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -1,5 +1,8 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 OUTPUT_DIR=out
 mkdir -p ${OUTPUT_DIR}


### PR DESCRIPTION
`[[` is not installed on lab nodes:

```
ubuntu@nuc-07:~/workspace/cluster-api-provider-ssh/clusterctl/examples/ssh$ ./generate-yaml.sh 
using empty pass phrase to private key
./generate-yaml.sh: 73: ./generate-yaml.sh: [[: not found
./generate-yaml.sh: 75: ./generate-yaml.sh: [[: not found
Unrecognized OS : Linux
ubuntu@nuc-07:~...
```