### PR TITLE
Set the DEBIAN_FRONTEND to noninteractive

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/master_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_ubuntu_16.04.template
@@ -2,6 +2,10 @@
           set -x
           (
           ARCH=amd64
+
+          # Run in noninteractive mode to avoid erroring when a config file preexists.
+          export DEBIAN_FRONTEND=noninteractive
+
           sudo apt update && sudo apt install -y apt-transport-https curl
 
           curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_ubuntu_16.04.template
@@ -1,6 +1,9 @@
           set -e
           set -x
           (
+          # Run in noninteractive mode to avoid erroring when a config file preexists.
+          export DEBIAN_FRONTEND=noninteractive
+
           sudo apt update
           sudo apt install -y apt-transport-https prips
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys F76221572C52609D


### PR DESCRIPTION
If a config file exists when apt tries to install or update a package,
it will error as there is no tty. Setting this variable to
noninteractive configures apt to run in a script.