### PR TITLE
Add the missing podCIDR to the kubeadm config

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/master_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_ubuntu_16.04.template
@@ -82,6 +82,7 @@
           networking:
             dsnDomain: ${CLUSTER_DNS_DOMAIN}
             serviceSubnet: ${SERVICE_CIDR}
+            podSubnet: ${POD_CIDR}
           EOF
 
           # Create and set bridge-nf-call-iptables to 1 to pass the kubeadm preflight check.


### PR DESCRIPTION
In order for flannel to start successfully, the podCIDR needs to be
configured by kubeadm. Add it to the network section of the config yaml.