### PR TITLE
Use ServiceAccount

### DIFF
--- a/clusterctl/examples/ssh/cluster.yaml.template
+++ b/clusterctl/examples/ssh/cluster.yaml.template
@@ -14,3 +14,4 @@ spec:
       apiVersion: "sshproviderconfig/v1alpha1"
       kind: "SSHClusterProviderConfig"
 
+# vim: ft=yaml:ts=2:sw=2

--- a/clusterctl/examples/ssh/machines.yaml.template
+++ b/clusterctl/examples/ssh/machines.yaml.template
@@ -38,3 +38,5 @@ items:
           secretName: cluster-private-key
     versions:
       kubelet: 1.10.6
+
+# vim: ft=yaml:ts=2:sw=2

--- a/clusterctl/examples/ssh/provider-components.yaml.template
+++ b/clusterctl/examples/ssh/provider-components.yaml.template
@@ -1,3 +1,48 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusterapi
+  namespace: default
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: clusterapi
+rules:
+- apiGroups: [""]
+  resources: 
+  - "endpoints"
+  - "events"
+  - "nodes"
+  - "secrets"
+  verbs: 
+  - "*"
+- apiGroups: ["cluster.k8s.io"]
+  resources: 
+  - "clusters"
+  - "machinedeployments"
+  - "machines"
+  - "machines/status"
+  - "machinesets"
+  verbs: 
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterapi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterapi
+subjects:
+- kind: ServiceAccount
+  name: clusterapi
+  namespace: default
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -11,6 +56,7 @@ spec:
       labels:
         api: clusterapi
     spec:
+      serviceAccountName: clusterapi
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
@@ -27,15 +73,9 @@ spec:
       containers:
       - name: controller-manager
         image: gcr.io/k8s-cluster-api/controller-manager:0.0.8
-        volumeMounts:
-          - name: config
-            mountPath: /etc/kubernetes
-          - name: certs
-            mountPath: /etc/ssl/certs
         command:
         - "./controller-manager"
         args:
-        - --kubeconfig=/etc/kubernetes/admin.conf
         - --leader-elect
         resources:
           requests:
@@ -47,10 +87,6 @@ spec:
       - name: ssh-cluster-controller
         image: quay.io/samsung_cnct/ssh-cluster-controller:prod
         volumeMounts:
-          - name: config
-            mountPath: /etc/kubernetes
-          - name: certs
-            mountPath: /etc/ssl/certs
           - name: machine-setup
             mountPath: /etc/machinesetup
         env:
@@ -61,7 +97,6 @@ spec:
         command:
         - "./cluster-controller"
         args:
-        - --kubeconfig=/etc/kubernetes/admin.conf
         - --leader-elect
         resources:
           requests:
@@ -73,10 +108,6 @@ spec:
       - name: ssh-machine-controller
         image: quay.io/samsung_cnct/ssh-machine-controller:prod
         volumeMounts:
-          - name: config
-            mountPath: /etc/kubernetes
-          - name: certs
-            mountPath: /etc/ssl/certs
           - name: machine-setup
             mountPath: /etc/machinesetup
           - name: kubeadm
@@ -89,7 +120,6 @@ spec:
         command:
         - "./machine-controller"
         args:
-        - --kubeconfig=/etc/kubernetes/admin.conf
         - --machinesetup=/etc/machinesetup/machine_setup_configs.yaml
         - --leader-elect
         resources:
@@ -100,12 +130,6 @@ spec:
             cpu: 400m
             memory: 500Mi
       volumes:
-      - name: config
-        hostPath:
-          path: /etc/kubernetes
-      - name: certs
-        hostPath:
-          path: /etc/ssl/certs
       - name: machine-setup
         configMap:
           name: machine-setup
@@ -153,4 +177,4 @@ data:
         shutdownScript: |
           $NODE_TEARDOWN_SCRIPT
 
-
+# vim: ft=yaml:ts=2:sw=2

--- a/cmd/machine-controller/Dockerfile
+++ b/cmd/machine-controller/Dockerfile
@@ -27,3 +27,4 @@ FROM debian:stretch-slim
 RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/machine-controller .
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-ssh/cmd/machine-controller/kubeadm.kubeconfig /etc/kubernetes/admin.conf

--- a/cmd/machine-controller/kubeadm.kubeconfig
+++ b/cmd/machine-controller/kubeadm.kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: default
+  cluster:
+    server: https://kubernetes/
+    certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+contexts:
+- name: default
+  context:
+    cluster: default
+    namespace: default
+    user: default
+current-context: default
+users:
+- name: default
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Instead of mounting the admin kubeconfig, use a ServiceAccount and RBAC
to provide the needed access.