### PR TITLE
Make kubeadmToken errors useful

### DIFF
--- a/cloud/ssh/actuators/machine/actuator_helper.go
+++ b/cloud/ssh/actuators/machine/actuator_helper.go
@@ -122,7 +122,7 @@ func (a *Actuator) getKubeadmToken() (string, error) {
 	}
 	output, err := a.kubeadm.TokenCreate(tokenParams)
 	if err != nil {
-		glog.Errorf("unable to create token: %v", err)
+		glog.Errorf("unable to create token: %s, %v", output, err)
 		return "", err
 	}
 	return strings.TrimSpace(output), err


### PR DESCRIPTION
The err string is nothing more than the exit code. Add the output of the
command to give context to the exit code.