### PR TITLE
Script to clean external cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,3 @@ index 8fac530..3d6c246 100644
 <a name="kvm2">1</a> If using minikube on linux, you may prefer to use the
 [kvm2 driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver).
 To do so, add the `--vm-driver=kvm2` flag after installing the driver.
-

--- a/README.md
+++ b/README.md
@@ -140,34 +140,3 @@ index 8fac530..3d6c246 100644
 [kvm2 driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver).
 To do so, add the `--vm-driver=kvm2` flag after installing the driver.
 
-## Cleaning External Cluster for Dev Work
-There is a tool to help you dev quickly and redeploy with clean states, the script is located in the hack directory.
-First a few assumptions:
-
-- Using pivoting. 
-- Using an external cluster such as minikube, or your own.
-- minikube/external cluster has kubeconfig file either exported in env variable or in the default directory.
-
-So first create a cluster as part of your dev cycle
-
-```
-$ ./bin/clusterctl create cluster -v 7 --provider ssh -c ./clusterctl/examples/ssh/out/cluster.yaml -m ./clusterctl/examples/ssh/out/machines.yaml -p ./clusterctl/examples/ssh/out/provider-components.yaml --existing-bootstrap-cluster-kubeconfig=minikube.kubeconfig
-```
-Notice that we are using the `--existing-bootstrap-cluster-kubeconfig` flag, that way we do not have to recreate minikube over and over which takes a very long time.
-Now, we have finished, pivoted, and completed (whether succeeded or not), next step is to just clean our cluster for the next cycle:
-
-```
-$./hack/delete_deployments.sh ssh-controlplane-c97bl new-test-1
-Deleting machine object
-machine.cluster.k8s.io/ssh-controlplane-c97bl patched
-machine.cluster.k8s.io "ssh-controlplane-c97bl" deleted
-Deleting cluster object
-cluster.cluster.k8s.io/new-test-1 patched
-cluster.cluster.k8s.io "new-test-1" deleted
-configmap "machine-setup" deleted
-configmap "cluster-info" deleted
-deployment.extensions "clusterapi-controllers" deleted
-deployment.extensions "clusterapi-apiserver" deleted
-statefulset.apps "etcd-clusterapi" deleted
-```
-That should be it, your cluster is good for another run.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,35 @@ index 8fac530..3d6c246 100644
 <a name="kvm2">1</a> If using minikube on linux, you may prefer to use the
 [kvm2 driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver).
 To do so, add the `--vm-driver=kvm2` flag after installing the driver.
+
+## Cleaning External Cluster for Dev Work
+There is a tool to help you dev quickly and redeploy with clean states, the script is located in the hack directory.
+First a few assumptions:
+
+- Using pivoting. 
+- Using an external cluster such as minikube, or your own.
+- minikube/external cluster has kubeconfig file either exported in env variable or in the default directory.
+
+So first create a cluster as part of your dev cycle
+
+```
+$ ./bin/clusterctl create cluster -v 7 --provider ssh -c ./clusterctl/examples/ssh/out/cluster.yaml -m ./clusterctl/examples/ssh/out/machines.yaml -p ./clusterctl/examples/ssh/out/provider-components.yaml --existing-bootstrap-cluster-kubeconfig=minikube.kubeconfig
+```
+Notice that we are using the `--existing-bootstrap-cluster-kubeconfig` flag, that way we do not have to recreate minikube over and over which takes a very long time.
+Now, we have finished, pivoted, and completed (whether succeeded or not), next step is to just clean our cluster for the next cycle:
+
+```
+$./hack/delete_deployments.sh ssh-controlplane-c97bl new-test-1
+Deleting machine object
+machine.cluster.k8s.io/ssh-controlplane-c97bl patched
+machine.cluster.k8s.io "ssh-controlplane-c97bl" deleted
+Deleting cluster object
+cluster.cluster.k8s.io/new-test-1 patched
+cluster.cluster.k8s.io "new-test-1" deleted
+configmap "machine-setup" deleted
+configmap "cluster-info" deleted
+deployment.extensions "clusterapi-controllers" deleted
+deployment.extensions "clusterapi-apiserver" deleted
+statefulset.apps "etcd-clusterapi" deleted
+```
+That should be it, your cluster is good for another run.

--- a/hack/clean-external-cluster.sh
+++ b/hack/clean-external-cluster.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# To be used when using either minikube or an external cluster
+# deletes resources created by using clusterctl WITH pivoting
+# If not using pivoting it may NOT be a good idea to do this
+# Since in that case machine and cluster resources may in fact
+# exist in a way that delete would and should actually delete these.
+
+machine=$1
+cluster=$2
+
+
+echo "Deleting machine object"
+kubectl patch machine ${machine} -p '{"metadata":{"finalizers": [null]}}'
+kubectl delete machine ${machine}
+
+echo "Deleting cluster object"
+kubectl patch cluster ${cluster} -p '{"metadata":{"finalizers": [null]}}'
+kubectl delete cluster ${cluster}
+
+kubectl delete configmap machine-setup -n default
+kubectl delete configmap cluster-info -n kube-public
+
+kubectl delete deployment clusterapi-controllers
+kubectl delete deployment clusterapi-apiserver
+kubectl delete statefulsets  etcd-clusterapi


### PR DESCRIPTION
Script added to had directory, including additional comments on Readme file. This should go away once clean up is merged, but for now this should save us all time. 