### PR TITLE
Removes `make` from top level README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ your $GOPATH as follows:
 mkdir -p $GOPATH/src/sigs.k8s.io/
 git clone https://github.com/samsung-cnct/cluster-api-provider-ssh.git $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
-make
 ```
 
 ## Generating cluster, machine, and provider-components files


### PR DESCRIPTION
As per PR #57, `make help` is now the default behavior when running `make` instead of `make all`.
Hovever, none of the commands of `make all` are actually necessary to follow the README instructions and so the prompt should be removed altogether.