### PR TITLE
Allows to configure kubeadm to use the IP address of the controlplane machine

### DIFF
--- a/cloud/ssh/actuators/machine/actuator.go
+++ b/cloud/ssh/actuators/machine/actuator.go
@@ -127,7 +127,7 @@ func (a *Actuator) Create(c *clusterv1.Cluster, m *clusterv1.Machine) error {
 		Versions: m.Spec.Versions,
 	}
 
-	metadata, err := a.getMetadata(c, m, configParams)
+	metadata, err := a.getMetadata(c, m, configParams, machineConfig.SSHConfig)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func (a *Actuator) Delete(c *clusterv1.Cluster, m *clusterv1.Machine) error {
 		Versions: m.Spec.Versions,
 	}
 
-	metadata, err := a.getMetadata(c, m, configParams)
+	metadata, err := a.getMetadata(c, m, configParams, machineConfig.SSHConfig)
 	if err != nil {
 		return err
 	}

--- a/cloud/ssh/actuators/machine/actuator_helper.go
+++ b/cloud/ssh/actuators/machine/actuator_helper.go
@@ -56,7 +56,7 @@ func (a *Actuator) handleMachineError(machine *clusterv1.Machine, err *apierrors
 	return err
 }
 
-func (a *Actuator) getMetadata(c *clusterv1.Cluster, m *clusterv1.Machine, machineParams *MachineParams) (*Metadata, error) {
+func (a *Actuator) getMetadata(c *clusterv1.Cluster, m *clusterv1.Machine, machineParams *MachineParams, sshConfig v1alpha1.SSHConfig) (*Metadata, error) {
 	var err error
 	metadataMap := make(map[string]string)
 
@@ -80,7 +80,7 @@ func (a *Actuator) getMetadata(c *clusterv1.Cluster, m *clusterv1.Machine, machi
 				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), createEventAction)
 		}
 
-		masterMap, err := masterMetadata(c, m, &machineSetupMetadata)
+		masterMap, err := masterMetadata(c, m, &machineSetupMetadata, sshConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/cloud/ssh/actuators/machine/setupconfigs_metadata.go
+++ b/cloud/ssh/actuators/machine/setupconfigs_metadata.go
@@ -110,10 +110,6 @@ func getSubnet(netRange clusterv1.NetworkRanges) string {
 	return netRange.CIDRBlocks[0]
 }
 
-func getMachineHostAndPor(m *clusterv1.Machine) {
-
-}
-
 const masterEnvironmentVars = `#!/bin/bash
 KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
 VERSION=v${KUBELET_VERSION}

--- a/cloud/ssh/actuators/machine/setupconfigs_metadata.go
+++ b/cloud/ssh/actuators/machine/setupconfigs_metadata.go
@@ -8,6 +8,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"fmt"
+
+	"sigs.k8s.io/cluster-api-provider-ssh/cloud/ssh/providerconfig/v1alpha1"
 )
 
 var (
@@ -35,16 +37,18 @@ type metadataParams struct {
 	// These fields are set when executing the template if they are necessary.
 	PodCIDR        string
 	ServiceCIDR    string
-	MasterEndpoint string
+	MasterEndpoint string // for node joining a cluster, should be available after master created
+	MasterIP       string // for injection to startup script
 }
 
-func masterMetadata(c *clusterv1.Cluster, m *clusterv1.Machine, metadata *Metadata) (map[string]string, error) {
+func masterMetadata(c *clusterv1.Cluster, m *clusterv1.Machine, metadata *Metadata, sshConfig v1alpha1.SSHConfig) (map[string]string, error) {
 	params := metadataParams{
 		Cluster:     c,
 		Machine:     m,
 		Metadata:    metadata,
 		PodCIDR:     getSubnet(c.Spec.ClusterNetwork.Pods),
 		ServiceCIDR: getSubnet(c.Spec.ClusterNetwork.Services),
+		MasterIP:    sshConfig.Host,
 	}
 	masterMetadata := map[string]string{}
 	var buf bytes.Buffer
@@ -106,6 +110,10 @@ func getSubnet(netRange clusterv1.NetworkRanges) string {
 	return netRange.CIDRBlocks[0]
 }
 
+func getMachineHostAndPor(m *clusterv1.Machine) {
+
+}
+
 const masterEnvironmentVars = `#!/bin/bash
 KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
 VERSION=v${KUBELET_VERSION}
@@ -118,6 +126,7 @@ CONTROL_PLANE_VERSION={{ .Machine.Spec.Versions.ControlPlane }}
 CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
 POD_CIDR={{ .PodCIDR }}
 SERVICE_CIDR={{ .ServiceCIDR }}
+MASTER_IP={{ .MasterIP }}
 `
 const nodeEnvironmentVars = `#!/bin/bash
 KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
@@ -69,6 +69,7 @@
           apiVersion: kubeadm.k8s.io/v1alpha1
           kind: MasterConfiguration
           api:
+            advertiseAddress: ${MASTER_IP}
             bindPort: 443
           etcd:
             local:

--- a/vendor/sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/vendor/sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/clusterdeployer.go
@@ -114,15 +114,12 @@ const (
 
 func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider ProviderDeployer, kubeconfigOutput string, providerComponentsStoreFactory ProviderComponentsStoreFactory) error {
 	master, nodes, err := extractMasterMachine(machines)
-
-	workingNS := master.Namespace
-
 	if err != nil {
 		return fmt.Errorf("unable to seperate master machines from node machines: %v", err)
 	}
 
 	glog.Info("Creating external cluster")
-	externalClient, cleanupExternalCluster, err := d.createExternalCluster(workingNS)
+	externalClient, cleanupExternalCluster, err := d.createExternalCluster()
 	defer cleanupExternalCluster()
 	if err != nil {
 		return fmt.Errorf("could not create external client: %v", err)
@@ -227,7 +224,7 @@ func (d *ClusterDeployer) Delete(internalClient ClusterClient) error {
 	return nil
 }
 
-func (d *ClusterDeployer) createExternalCluster(ns api.Namespace) (ClusterClient, func(), error) {
+func (d *ClusterDeployer) createExternalCluster() (ClusterClient, func(), error) {
 	cleanupFn := func() {}
 	if err := d.externalProvisioner.Create(); err != nil {
 		return nil, cleanupFn, fmt.Errorf("could not create external control plane: %v", err)


### PR DESCRIPTION
Allows the use of the defined ip address when setting up kubernetes, while not using the default ip in networking config of the machine. Should alleviate issues we saw when trying to run against aws. 