### PR TITLE
Revert "Cleanup annotation used to synchronize the deployer with the actuator"

### DIFF
--- a/cloud/ssh/actuators/machine/actuator.go
+++ b/cloud/ssh/actuators/machine/actuator.go
@@ -149,8 +149,7 @@ func (a *Actuator) Create(c *clusterv1.Cluster, m *clusterv1.Machine) error {
 	glog.Infof("Annotating machine %s for cluster %s.", m.Name, c.Name)
 
 	a.eventRecorder.Eventf(m, corev1.EventTypeNormal, "Created", "Created Machine %v", m.Name)
-
-	return a.updateStatusAndAnnotations(c, m)
+	return a.updateAnnotations(c, m)
 }
 
 // Delete deletes a machine and is invoked by the Machine Controller
@@ -276,27 +275,19 @@ func (a *Actuator) Update(c *clusterv1.Cluster, goalMachine *clusterv1.Machine) 
 		}
 	}
 
-	return a.updateStatusAndAnnotations(c, goalMachine)
+	a.eventRecorder.Eventf(goalMachine, corev1.EventTypeNormal, "Updated", "Updated Machine %v", goalMachine.Name)
+	return a.updateAnnotations(c, goalMachine)
 }
 
 // Exists test for the existance of a machine and is invoked by the Machine Controller
 func (a *Actuator) Exists(c *clusterv1.Cluster, m *clusterv1.Machine) (bool, error) {
 	glog.Infof("Checking if machine %s for cluster %s exists.", m.Name, c.Name)
 	// Try to use the last saved status locating the machine
-
-	if a.v1Alpha1Client == nil {
-		return false, nil
-	}
-
-	currentMachine, err := util.GetMachineIfExists(a.v1Alpha1Client.Machines(m.Namespace), m.Name)
+	status, err := a.status(m)
 	if err != nil {
 		return false, err
 	}
-
-	annotations := currentMachine.Annotations
-	if annotations == nil {
-		return false, nil
-	}
-
-	return len(annotations) > 0, nil
+	// if status is nil, either it doesnt exist or bootstrapping, however in ssh we assume it exists.
+	// so some status must be returned.
+	return status != nil, nil
 }

--- a/cloud/ssh/actuators/machine/actuator_status.go
+++ b/cloud/ssh/actuators/machine/actuator_status.go
@@ -3,74 +3,139 @@ package machine
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/util"
 )
+
+type MachineStatus *clusterv1.Machine
+
+type AnnotationKey string
 
 const (
-	MachineNameAnnotationKey = "machine"
+	InstanceStatus AnnotationKey = "instance-status"
+	Name           AnnotationKey = "machine-name"
 )
 
-// In the future we will not use annotations )?) in that case we will no longer need this method
-func (a *Actuator) updateStatusAndAnnotations(c *clusterv1.Cluster, m *clusterv1.Machine) error {
-	err := a.updateStatus(c, m)
+// Get the status of the instance identified by the given machine
+func (a *Actuator) status(m *clusterv1.Machine) (MachineStatus, error) {
+	if a.v1Alpha1Client == nil {
+		return nil, nil
+	}
+	currentMachine, err := util.GetMachineIfExists(a.v1Alpha1Client.Machines(m.Namespace), m.ObjectMeta.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return a.updateAnnotations(c, m)
+	if currentMachine == nil {
+		// The current status no longer exists because the matching CRD has been deleted (or does not exist yet ie. bootstrapping)
+		return nil, nil
+	}
+	return a.machineStatus(currentMachine)
+}
+
+// Gets the state of the instance stored on the given machine CRD
+func (a *Actuator) machineStatus(m *clusterv1.Machine) (MachineStatus, error) {
+	if m.ObjectMeta.Annotations == nil {
+		return nil, nil
+	}
+
+	annot := m.ObjectMeta.Annotations[string(InstanceStatus)]
+	if annot == "" {
+		return nil, nil
+	}
+
+	serializer := json.NewSerializer(json.DefaultMetaFactory, a.scheme, a.scheme, false)
+	var status clusterv1.Machine
+	_, _, err := serializer.Decode([]byte(annot), &schema.GroupVersionKind{Group: "", Version: "cluster.k8s.io/v1alpha1", Kind: "Machine"}, &status)
+	if err != nil {
+		return nil, fmt.Errorf("decoding failure: %v", err)
+	}
+
+	return MachineStatus(&status), nil
 }
 
 // Sets the status of the instance identified by the given machine to the given machine
-func (a *Actuator) updateStatus(c *clusterv1.Cluster, m *clusterv1.Machine) error {
+func (a *Actuator) updateStatus(machine *clusterv1.Machine) error {
 	if a.v1Alpha1Client == nil {
 		return nil
 	}
-
-	exists, err := a.Exists(c, m)
+	status := MachineStatus(machine)
+	currentMachine, err := util.GetMachineIfExists(a.v1Alpha1Client.Machines(machine.Namespace), machine.ObjectMeta.Name)
 	if err != nil {
 		return err
 	}
 
-	if !exists {
+	if currentMachine == nil {
 		// The current status no longer exists because the matching CRD has been deleted.
-		return fmt.Errorf("Machine has already been deleted. Cannot update current instance status for machine %s", m.Name)
+		return fmt.Errorf("Machine has already been deleted. Cannot update current instance status for machine %v", machine.ObjectMeta.Name)
 	}
 
-	m.Status = clusterv1.MachineStatus{
-		LastUpdated: metav1.Now(),
-		Versions: &m.Spec.Versions,
+	m, err := a.setMachineStatus(currentMachine, status)
+	if err != nil {
+		return err
 	}
 
-	_, err = a.v1Alpha1Client.Machines(m.Namespace).UpdateStatus(m)
+	_, err = a.v1Alpha1Client.Machines(machine.Namespace).Update(m)
 	return err
 }
 
-func (a *Actuator) updateAnnotations(c *clusterv1.Cluster, m *clusterv1.Machine) error {
+// Applies the state of an instance onto a given machine CRD
+func (a *Actuator) setMachineStatus(machine *clusterv1.Machine, status MachineStatus) (*clusterv1.Machine, error) {
+	// Avoid status within status within status ...
+	status.ObjectMeta.Annotations[string(InstanceStatus)] = ""
+
+	serializer := json.NewSerializer(json.DefaultMetaFactory, a.scheme, a.scheme, false)
+	b := []byte{}
+	buff := bytes.NewBuffer(b)
+	err := serializer.Encode((*clusterv1.Machine)(status), buff)
+	if err != nil {
+		return nil, fmt.Errorf("encoding failure: %v", err)
+	}
+
+	if machine.ObjectMeta.Annotations == nil {
+		machine.ObjectMeta.Annotations = make(map[string]string)
+	}
+	machine.ObjectMeta.Annotations[string(InstanceStatus)] = buff.String()
+	return machine, nil
+}
+
+func (a *Actuator) updateAnnotations(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if a.v1Alpha1Client == nil {
 		return nil
 	}
 
-	annotations := m.ObjectMeta.Annotations
+	name := machine.ObjectMeta.Name
+
+	annotations := machine.ObjectMeta.Annotations
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 
-	annotations[MachineNameAnnotationKey] = m.Name
-	m.ObjectMeta.Annotations = annotations
+	annotations[string(Name)] = name
+	machine.ObjectMeta.Annotations = annotations
 
-	_, err := a.v1Alpha1Client.Machines(m.Namespace).Update(m)
-	return err
+	_, err := a.v1Alpha1Client.Machines(machine.Namespace).Update(machine)
+	if err != nil {
+		return err
+	}
+	return a.updateStatus(machine)
 }
 
-func (a *Actuator) deleteAnnotations(c *clusterv1.Cluster, m *clusterv1.Machine) error {
+func (a *Actuator) deleteAnnotations(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if a.v1Alpha1Client == nil {
 		return nil
 	}
 
 	annotations := make(map[string]string)
-	m.ObjectMeta.Annotations = annotations
+	machine.ObjectMeta.Annotations = annotations
 
-	_, err := a.v1Alpha1Client.Machines(m.Namespace).Update(m)
-	return err
+	_, err := a.v1Alpha1Client.Machines(machine.Namespace).Update(machine)
+	if err != nil {
+		return err
+	}
+	return a.updateStatus(machine)
 }


### PR DESCRIPTION
Reverts samsung-cnct/cluster-api-provider-ssh#67 There are two problems: 1) updateStatusAndAnnotations() will not add an annotation if Exists() fails, and Exists() will always fail if there is no annotation. 2) updateStatusAndAnnotations() attempts to make two updates using the same Machine object so that the second attempt will always fail.