### PR TITLE
delete fix, and moved code to getKubeadmTokenOnMaster

### DIFF
--- a/cloud/ssh/actuators/machine/setupconfigs_metadata.go
+++ b/cloud/ssh/actuators/machine/setupconfigs_metadata.go
@@ -85,7 +85,7 @@ func nodeMetadata(token string, c *clusterv1.Cluster, m *clusterv1.Machine, meta
 		ServiceCIDR:    getSubnet(c.Spec.ClusterNetwork.Services),
 		MasterEndpoint: getEndpoint(c.Status.APIEndpoints[0]),
 	}
-	glog.Infof("nodeMetadata: params.MasterEndpoint = ", params.MasterEndpoint)
+	glog.Infof("The MasterEndpoint = %s, machine %s cluster %s", params.MasterEndpoint, m.Name, c.Name)
 	var buf bytes.Buffer
 
 	if err := nodeEnvironmentVarsTemplate.Execute(&buf, params); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a delete error when the control-plane node is deleted before the worker node, and the worker node delete was throwing an error.  In the case of delete, we should not be trying to ssh to the master node to create a token.  Token creation is only needed when a new node wants to join the cluster.  The attempt to run kubeadm on a deleted master was causing the error.  This fix allows deletion of the cluster in any order.
The code to create the kubeadm token on the master (using ssh) was moved to it's own method,
getKubeadmTokenOnMaster.  A ttl of ten minutes was added.  A few error messages were improved.
**Which issue(s) this PR fixes** : 
This fixes CMS-351 https://samsung-cnct.atlassian.net/browse/CMS-351

