### PR TITLE
Create a secret containing the cluster kubeconfig

### DIFF
--- a/cloud/ssh/actuators/machine/actuator.go
+++ b/cloud/ssh/actuators/machine/actuator.go
@@ -154,6 +154,11 @@ func (a *Actuator) Create(c *clusterv1.Cluster, m *clusterv1.Machine) error {
 		if err != nil {
 			return err
 		}
+		// create kubeconfig secret
+		err = a.createKubeconfigSecret(c, m, sshClient)
+		if err != nil {
+			return err
+		}
 	}
 
 	a.eventRecorder.Eventf(m, corev1.EventTypeNormal, "Created", "Created Machine %v", m.Name)

--- a/cloud/ssh/sshproviderclient.go
+++ b/cloud/ssh/sshproviderclient.go
@@ -11,11 +11,16 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ssh/cloud/ssh/providerconfig/v1alpha1"
 )
 
+const (
+	GetKubeconfigCommand = "sudo cat /etc/kubernetes/admin.conf"
+)
+
 type SSHProviderClientInterface interface {
 	ProcessCMD(cmd string) error
 	WritePublicKeys(machineSSHConfig v1alpha1.SSHConfig) error
 	DeletePublicKeys(machineSSHConfig v1alpha1.SSHConfig) error
 	GetKubeConfig() (string, error)
+	GetKubeConfigBytes() ([]byte, error)
 }
 
 type sshProviderClient struct {
@@ -45,12 +50,21 @@ func (s *sshProviderClient) DeletePublicKeys(machineSSHConfig v1alpha1.SSHConfig
 }
 
 func (s *sshProviderClient) GetKubeConfig() (string, error) {
-	bytes, err := s.ProcessCMDWithOutput("sudo cat /etc/kubernetes/admin.conf")
+	bytes, err := s.ProcessCMDWithOutput(GetKubeconfigCommand)
 	if err != nil {
 		return "", err
 	}
 
 	return string(bytes), nil
+}
+
+func (s *sshProviderClient) GetKubeConfigBytes() ([]byte, error) {
+	bytes, err := s.ProcessCMDWithOutput(GetKubeconfigCommand)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
 }
 
 func (s *sshProviderClient) ProcessCMD(cmd string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates a kubeconfig secret in the correct namespace for each cluster whose Master has been initialized.  This is needed by the UI (CMA) to return the kubeconfig to the user.