### PR TITLE
Removes final references to k8s sigs from nonvendor codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ For example:
 - push both ssh-cluster-controller and ssh-machine-controller images
 
 ```bash
-cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 make dev_push
 
 ```
@@ -95,14 +94,12 @@ make dev_push
 - push ssh-machine-controller image
 
 ```bash
-cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 make dev_push_machine
 ```
 
 - push ssh-cluster-controller image
 
 ```bash
-cd $GOPATH/src/sigs.k8s.io/cluster-api-provider-ssh
 make dev_push_cluster
 ```
 

--- a/cloud/ssh/providerconfig/doc.go
+++ b/cloud/ssh/providerconfig/doc.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-ssh/cloud/ssh/providerconfig
+// +k8s:conversion-gen=samsung-cnct/cloud/ssh/providerconfig
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 

--- a/cloud/ssh/providerconfig/v1alpha1/doc.go
+++ b/cloud/ssh/providerconfig/v1alpha1/doc.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-ssh/cloud/ssh/providerconfig
+// +k8s:conversion-gen=samsung-cnct/cluster-api-provider-ssh/cloud/ssh/providerconfig
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 


### PR DESCRIPTION
There were a couple leftover references to clean up.