### PR TITLE
allow worker node teardown to complete if master is gone

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_ubuntu_16.04.template
@@ -5,7 +5,7 @@
 
           #TODO do we drain? or require the operator of the machine to drain before updating? a node has no permission to do so internally
           # sudo kubectl --kubeconfig=/etc/kubernetes/kubelet.conf drain $(hostname) --delete-local-data --ignore-daemonsets --force
-          sudo kubectl --kubeconfig=/etc/kubernetes/kubelet.conf delete node $(hostname)
+          sudo kubectl --kubeconfig=/etc/kubernetes/kubelet.conf delete node $(hostname) || true
 
           sudo kubeadm reset
 


### PR DESCRIPTION
When you delete the controlplane machine first before deleting the worker node, the worker node was exiting out of it's teardown script because it was trying to run a kubectl command .  This change makes the bash script ignore the command if it errors and continue cleanup.