### PR TITLE
Fixes to update for master and worker nodes

### DIFF
--- a/cloud/ssh/sshproviderclient.go
+++ b/cloud/ssh/sshproviderclient.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	"github.com/samsung-cnct/cluster-api-provider-ssh/cloud/ssh/providerconfig/v1alpha1"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"github.com/samsung-cnct/cluster-api-provider-ssh/cloud/ssh/providerconfig/v1alpha1"
 )
 
 const (
@@ -17,6 +17,7 @@ const (
 
 type SSHProviderClientInterface interface {
 	ProcessCMD(cmd string) error
+	ProcessCMDWithOutput(cmd string) ([]byte, error)
 	WritePublicKeys(machineSSHConfig v1alpha1.SSHConfig) error
 	DeletePublicKeys(machineSSHConfig v1alpha1.SSHConfig) error
 	GetKubeConfig() (string, error)


### PR DESCRIPTION
This allows kubernetes upgrades from versions 1.10.x to 1.11.x.
I did a slight refactor (getMasterSSHClient) to avoid code duplication.

Upgrade version on the controlplane machine first.
Upgrade each worker node machine version individually.
Wait for each machine to be upgraded before upgrading the next one.  You can use kubectl get nodes to see the version of each node. You can also do kubectl describe machine <> --namespace <> to look for a successful Upgrade event: 
Events:
  Type    Reason   Age   From                    Message
  ----    ------   ----  ----                    -------
  Normal  Created  30m   ssh-machine-controller  Created Machine ssh-controlplane-mqn7f
  Normal  Updated  17m   ssh-machine-controller  Updated Machine ssh-controlplane-mqn7f

