### PR TITLE
check version using kubectl get nodes

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_ubuntu_16.04.template
@@ -28,6 +28,9 @@
           sudo -E apt upgrade -y --allow-downgrades kubectl=${KUBECTL}
           sudo -E apt upgrade -y --allow-downgrades kubeadm=${KUBEADM}
           sudo -E apt upgrade -y --allow-downgrades kubelet=${KUBELET}
-          
+          # curl kubeadm to make sure it matches the desired version
+          sudo curl -o /usr/bin/kubeadm -sSL https://dl.k8s.io/release/v${CONTROL_PLANE_VERSION}/bin/linux/amd64/kubeadm
+          sudo chmod a+rx /usr/bin/kubeadm
+
           sudo systemctl restart kubelet
           ) 2>&1 | sudo tee /var/log/upgrade.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_ubuntu_16.04.template
@@ -27,7 +27,10 @@
           # upgrade kubelet last, so that dependencies don't overwrite the patch version
           sudo -E apt upgrade -y --allow-downgrades kubectl=${KUBECTL}
           sudo -E apt upgrade -y --allow-downgrades kubeadm=${KUBEADM}  
-          sudo -E apt upgrade -y --allow-downgrades kubelet=${KUBELET}              
+          sudo -E apt upgrade -y --allow-downgrades kubelet=${KUBELET}
+          # curl kubeadm to make sure it matches the desired version
+          sudo curl -o /usr/bin/kubeadm -sSL https://dl.k8s.io/release/v${KUBELET_VERSION}/bin/linux/amd64/kubeadm
+          sudo chmod a+rx /usr/bin/kubeadm
 
           sudo kubeadm upgrade node config --kubelet-version $(kubelet --version | cut -d ' ' -f 2)
           sudo systemctl restart kubelet


### PR DESCRIPTION
I found a case during update (upgrade) where the kubelet version was installed correctly, but kubelet couldn't start (due to the master being unavailable).  By checking the version from the nodes, we can see what version is truly running.  With this change, update will retry until the version matches what kubectl get nodes tells us is running.  I found that with this change, you can update by not waiting for the master to complete before updating the node versions ...although that would not be best practice.