### PR TITLE
Make configuration consistent

### DIFF
--- a/clusterctl/examples/ssh/README.md
+++ b/clusterctl/examples/ssh/README.md
@@ -32,10 +32,11 @@ For ubuntu (default):
 ./generate-yaml.sh
 ```
 
-For centos:
+For _air gapped_ centos:
 
 ```bash
-./generate-yaml.sh centos
+export OS_TYPE=centos
+./generate-yaml.sh
 ```
 
 Note: The current centos bootstrap scripts are very

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
@@ -90,10 +90,8 @@
           # http://zeeshanali.com/sysadmin/fixed-sysctl-cannot-stat-procsysnetbridgebridge-nf-call-iptables/
           sudo modprobe br_netfilter
 
-          # [ERROR Swap]: running with swap on is not supported. Please disable swap
-          # this was put in place since its something that must be done on ubuntu machines
-          # when provisioning for use with kubeadm. Note, kubelet requires this to be off
-          # and may be something we remove in the future and leave it as part of provisioning
+          # Allowing swap may not be reliable:
+          # https://github.com/kubernetes/kubernetes/issues/53533
           sudo swapoff -a
 
           sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
@@ -91,10 +91,8 @@
           # http://zeeshanali.com/sysadmin/fixed-sysctl-cannot-stat-procsysnetbridgebridge-nf-call-iptables/
           sudo modprobe br_netfilter
 
-          # [ERROR Swap]: running with swap on is not supported. Please disable swap
-          # this was put in place since its something that must be done on ubuntu machines
-          # when provisioning for use with kubeadm. Note, kubelet requires this to be off
-          # and may be something we remove in the future and leave it as part of provisioning
+          # Allowing swap may not be reliable:
+          # https://github.com/kubernetes/kubernetes/issues/53533
           sudo swapoff -a
 
           sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_air_gapped_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_air_gapped_centos_7.template
@@ -68,10 +68,8 @@
           # http://zeeshanali.com/sysadmin/fixed-sysctl-cannot-stat-procsysnetbridgebridge-nf-call-iptables/
           sudo modprobe br_netfilter
 
-          # [ERROR Swap]: running with swap on is not supported. Please disable swap
-          # this was put in place since its something that must be done on ubuntu machines
-          # when provisioning for use with kubeadm. Note, kubelet requires this to be off
-          # and may be something we remove in the future and leave it as part of provisioning
+          # Allowing swap may not be reliable:
+          # https://github.com/kubernetes/kubernetes/issues/53533
           sudo swapoff -a
 
           sudo kubeadm join --token "${TOKEN}" "${MASTER}" \

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_ubuntu_16.04.template
@@ -64,11 +64,10 @@
           sudo systemctl daemon-reload
           sudo systemctl restart kubelet.service
 
-           # [ERROR Swap]: running with swap on is not supported. Please disable swap
-           # this was put in place since its something that must be done on ubuntu machines
-           # when provisioning for use with kubeadm. Note, kubelet requires this to be off
-           # and may be something we remove in the future and leave it as part of provisioning
+          # Allowing swap may not be reliable:
+          # https://github.com/kubernetes/kubernetes/issues/53533
           sudo swapoff -a
+
           sudo kubeadm join --token "${TOKEN}" "${MASTER}" --ignore-preflight-errors=all --discovery-token-unsafe-skip-ca-verification
           for tries in $(seq 1 60); do
               sudo kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname) machine=${MACHINE} && break

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -4,12 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# All configuration is done using environment variables.
+if [ "$#" -ne 0 ]; then
+    echo "Illegal number of parameters"
+fi
+
 OUTPUT_DIR=out
 mkdir -p ${OUTPUT_DIR}
 
 BOOTSTRAP_DIR=bootstrap_scripts
 
-OS_TYPE=${1:-ubuntu}
+OS_TYPE=${OS_TYPE:-ubuntu}
 
 # --- MACHINES ---
 MACHINE_TEMPLATE_FILE=machines.yaml.template


### PR DESCRIPTION
Generate requires env vars (e.g. CLUSTER_PRIVATE_KEY) to function. The optional command line option is inconsistent and hidden. This makes all configuration use env vars and stops if unexpected parameters are provided.

Also clarifies why swap should be disabled.