### PR TITLE
Remove cluster actuator reconcile error

### DIFF
--- a/cloud/ssh/actuators/cluster/actuator.go
+++ b/cloud/ssh/actuators/cluster/actuator.go
@@ -14,8 +14,6 @@
 package cluster
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
@@ -41,7 +39,7 @@ func NewActuator(params ActuatorParams) (*Actuator, error) {
 // Reconcile reconciles a cluster and is invoked by the Cluster Controller
 func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 	glog.Infof("Reconciling cluster %v.", cluster.Name)
-	return fmt.Errorf("TODO: Not yet implemented")
+	return nil
 }
 
 // Delete deletes a cluster and is invoked by the Cluster Controller


### PR DESCRIPTION
Removed the error since we intentionally have nothing to do in the cluster reconcile method.

The ssh-cluster-controller log always outputs was outputting an error message during reconcile:
I1026 15:26:46.499791       1 controller.go:89] reconciling cluster object cindy triggers idempotent reconcile.
I1026 15:26:46.499857       1 actuator.go:43] Reconciling cluster cindy.
E1026 15:26:46.499874       1 controller.go:92] Error reconciling cluster object cindy; TODO: Not yet implemented

With this change the error is removed:
I1026 15:52:12.399956       1 controller.go:89] reconciling cluster object cindy triggers idempotent reconcile.
I1026 15:52:12.400106       1 actuator.go:41] Reconciling cluster cindy.