### PR TITLE
Added bootstrap templates for CentOS. They still need vetting. Fixed …

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
@@ -194,4 +194,7 @@
               sudo kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node "$(hostname)" machine="${MACHINE}" && break
               sleep 1
             done
+
+            # By default, use flannel for container network plugin, should make this configurable.
+            sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml
           }

--- a/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
@@ -15,13 +15,15 @@
 
           install_docker()
           {
-            # install and configure docker
-            if ! docker version >/dev/null 2>&1; then
-              if sudo yum install -y docker; then
-                echo >&2 "Success!"
+            local docker_service
 
-                return 0
-              else
+            docker_service='/usr/lib/systemd/system/docker.service'
+
+            # install and configure docker
+            if ! which docker 2>/dev/null; then
+              sudo yum install -y docker
+
+              if ! docker version >/dev/null 2>&1; then
                 return 50
               fi
             else
@@ -46,10 +48,19 @@
             }
             '
 
-            if ! sudo sed -r -i 's#^(ExecStart=/usr/bin/dockerd)#\1 --exec-opt native.cgroupdriver=systemd#' \
-                 /usr/lib/systemd/system/docker.service; then
-              echo >&2 'Unable to update docker.service with proper cgroupdriver.'
-              return 19
+            if [[ ! -f "$docker_service" ]]; then
+              echo >&2 'Cannot update docker.service file. "$docker_service" does not exist.'
+              return 16
+            fi
+
+            if [[ $(grep -c "native.cgroupdriver=systemd" "$docker_service" 2>/dev/null) == 0 ]]; then
+              if ! sudo sed -r -i 's#^(ExecStart=/usr/bin/dockerd)#\1 --exec-opt native.cgroupdriver=systemd#' \
+                   "$docker_service"; then
+                echo >&2 "Unable to update '$docker_service' with proper cgroupdriver."
+                return 19
+              fi
+            else
+              echo >&2 "WARNING: Looks like '$docker_service' was already updated. Skipping."
             fi
 
             if sudo cp /dev/stdin /etc/sysconfig/docker <<< 'DOCKER_OPTS="--iptables=false --ip-masq=false"'; then
@@ -60,8 +71,11 @@
               newgrp
 
               if sudo systemctl enable --now docker;then
-                if sudo systemctl daemon-reload; then
-                  return 50
+                if ! sudo systemctl daemon-reload; then
+                  echo >&2 "Unable to reload systemctl daemon."
+                  return 51
+                else
+                  sudo systemctl restart docker.service
                 fi
               else
                 return 51
@@ -73,9 +87,9 @@
 
           install_k8s()
           {
-            [[ -z ${KUBELET_VERSION} ]] &&\
+            [[ -z ${KUBELET_VERSION} ]] && \
               {
-                echo >&2 "Usage: install_k8s(): \$KUBELET_VERSION must be set."
+                echo >&2 'Usage: install_k8s(): caller must pass $KUBELET_VERSION.'
                 return 60
               }
 
@@ -136,25 +150,24 @@
           configure_kubelet()
           {
             # configure kubelet
-            sudo cp /dev/stdin /etc/systemd/system/kubelet.service.d/20-kubelet.conf <<< '[Service]
-            Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
-            '
+            sudo cp /dev/stdin /etc/systemd/system/kubelet.service.d/20-kubelet.conf <<< "[Service]
+          Environment='KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}'
+            "
             sudo systemctl enable --now kubelet
           }
 
           configure_kubeadm()
           {
-            if [[ $(sysctl -a 2>/dev/null | grep net.bridge.bridge-nf-call-iptables | cut -d = -f 2) != 1 ]];
-            then
-              sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
-            fi
+            sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+            sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=1
+            sudo sysctl -p
 
             if [[ $(systemctl is-active firewalld.service) == "active" ]]; then
                sudo systemctl disable --now firewalld
             fi
 
             # configure kubeadm
-            sudo cp /dev/stdin /etc/kubernetes/kubeadm_config.yaml <<< "
+            sudo cp /dev/stdin /etc/kubernetes/kubeadm_config.yaml <<< "---
             apiVersion: kubeadm.k8s.io/v1alpha1
             kind: MasterConfiguration
             api:
@@ -175,6 +188,9 @@
               serviceSubnet: ${SERVICE_CIDR}
             "
 
+            # YAML is whitespace picky. So, need to fix kubeadm_config
+            sudo sed -r -i 's#^[[:blank:]]{2}##' /etc/kubernetes/kubeadm_config.yaml
+
             # Create and set bridge-nf-call-iptables to 1 to pass the kubeadm preflight check.
             # Workaround was found here:
             # http://zeeshanali.com/sysadmin/fixed-sysctl-cannot-stat-procsysnetbridgebridge-nf-call-iptables/
@@ -189,7 +205,11 @@
 
           run_kubeadm_master()
           {
-            sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
+            if ! sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml; then
+              echo >&2 "Unable to start kubeadm."
+              return 95
+            fi
+
             for (( i = 0; i < 60; i++ )); do
               sudo kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node "$(hostname)" machine="${MACHINE}" && break
               sleep 1

--- a/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
@@ -187,7 +187,7 @@
             sudo swapoff -a
           }
 
-          run_kubeadm()
+          run_kubeadm_master()
           {
             sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
             for (( i = 0; i < 60; i++ )); do

--- a/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
@@ -26,7 +26,6 @@
               fi
             else
               echo >&2 "Skipping installation of docker. Already installed."
-              return 0
             fi
 
             # enable insecure image registry
@@ -47,7 +46,19 @@
             }
             '
 
+            if ! sudo sed -r -i 's#^(ExecStart=/usr/bin/dockerd)#\1 --exec-opt native.cgroupdriver=systemd#' \
+                 /usr/lib/systemd/system/docker.service; then
+              echo >&2 'Unable to update docker.service with proper cgroupdriver.'
+              return 19
+            fi
+
             if sudo cp /dev/stdin /etc/sysconfig/docker <<< 'DOCKER_OPTS="--iptables=false --ip-masq=false"'; then
+
+              [[ -z ${USER+x} ]] && USER=$(whoami)
+              sudo usermod -a -G docker $USER
+              sudo chmod 640 /etc/sysconfig/docker
+              newgrp
+
               if sudo systemctl enable --now docker;then
                 if sudo systemctl daemon-reload; then
                   return 50

--- a/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/common_functions.template
@@ -1,0 +1,186 @@
+
+          prune_kubeadm_env()
+          {
+            [[ -z "$1" ]] && \
+              {
+                echo >&2 "prune_kubeadm_env(): caller failed to pass required argument"
+                return 10
+              }
+
+            local what_to_prune=$1
+
+            # remove this from the current env file.
+            sudo sed -r -i 's#(KUBELET_KUBEADM_ARGS="?.*)'"${what_to_prune}"'(.*"?)#\1\2#' /var/lib/kubelet/kubeadm-flags.env
+          }
+
+          install_docker()
+          {
+            # install and configure docker
+            if ! docker version >/dev/null 2>&1; then
+              if sudo yum install -y docker; then
+                echo >&2 "Success!"
+
+                return 0
+              else
+                return 50
+              fi
+            else
+              echo >&2 "Skipping installation of docker. Already installed."
+              return 0
+            fi
+
+            # enable insecure image registry
+            sudo cp /dev/stdin /etc/docker/daemon.json  <<< '
+            {
+                "insecure-registries": [
+                    "docker",
+                    "docker.io",
+                    "registry-1.docker.io",
+                    "gcr.io",
+                    "k8s.gcr.io",
+                    "quay.io",
+                    "182.195.81.113:9401",
+                    "182.195.81.113:9402",
+                    "182.195.81.113:9403",
+                    "182.195.81.113:9404"
+                ]
+            }
+            '
+
+            if sudo cp /dev/stdin /etc/sysconfig/docker <<< 'DOCKER_OPTS="--iptables=false --ip-masq=false"'; then
+              if sudo systemctl enable --now docker;then
+                if sudo systemctl daemon-reload; then
+                  return 50
+                fi
+              else
+                return 51
+              fi
+            else
+              return 52
+            fi
+          }
+
+          install_k8s()
+          {
+            [[ -z ${KUBELET_VERSION} ]] &&\
+              {
+                echo >&2 "Usage: install_k8s(): \$KUBELET_VERSION must be set."
+                return 60
+              }
+
+            sudo cp /dev/stdin /etc/yum.repos.d/kubernetes.repo <<< '
+            [kubernetes]
+            name=Kubernetes
+            baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+            enabled=1
+            gpgcheck=1
+            repo_gpgcheck=1
+            gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+            exclude=kube*' && \
+
+            sudo sed -r -i 's#^\ +##g' /etc/yum.repos.d/kubernetes.repo
+
+            # Set SELinux in permissive mode (effectively disabling it)
+            sudo setenforce 0
+            sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+
+            sudo yum install -y "kubelet-${KUBELET_VERSION}" \
+                                "kubeadm-${KUBELET_VERSION}" \
+                                "kubectl-${KUBELET_VERSION}" \
+                                conntrack --disableexcludes=kubernetes
+
+            # See https://samsung-cnct.atlassian.net/browse/CMS-391
+            # If the file exists, grok it first (preserving current settings)
+            if [[ -f /var/lib/kubelet/kubeadm-flags.env ]]; then
+              source /var/lib/kubelet/kubeadm-flags.env
+
+              # prune arg we want to change
+              [[ -n "${KUBELET_KUBEADM_ARGS}" ]] && prune_kubeadm_env "--cgroup-driver"
+
+              # change the one we want to change
+              echo "KUBELET_KUBEADM_ARGS=$KUBELET_KUBEADM_ARGS --cgroup-driver=systemd" >> /var/lib/kubelet/kubeadm-flags.env
+            fi
+
+            sudo systemctl enable kubelet && sudo systemctl start kubelet
+          }
+
+          prips()
+          {
+            cidr=$1
+
+            # range is bounded by network (-n) & broadcast (-b) addresses.
+            # the following uses `read` with a here-statement to assign the output of
+            # ipcalc -bn into two variables; $hi and $lo the output of which is cut and then
+            # delimited by a ":". Read uses $IFS to automatically split on that delimiter.
+            IFS=':' read -r hi lo <<< "$(ipcalc -bn "$cidr" | cut -f 2 -d = | sed -r 'N;s/\n/:/')"
+
+            # similar to above only this is splitting on '.'.
+            IFS='.' read -r a b c d <<< "$lo"
+            IFS='.' read -r e f g h <<< "$hi"
+
+            # kubeadm uses 10th IP as DNS server
+            eval "echo {$a..$e}.{$b..$f}.{$c..$g}.{$d..$h}" | awk '{print $11}'
+          }
+
+          configure_kubelet()
+          {
+            # configure kubelet
+            sudo cp /dev/stdin /etc/systemd/system/kubelet.service.d/20-kubelet.conf <<< '[Service]
+            Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
+            '
+            sudo systemctl enable --now kubelet
+          }
+
+          configure_kubeadm()
+          {
+            if [[ $(sysctl -a 2>/dev/null | grep net.bridge.bridge-nf-call-iptables | cut -d = -f 2) != 1 ]];
+            then
+              sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+            fi
+
+            if [[ $(systemctl is-active firewalld.service) == "active" ]]; then
+               sudo systemctl disable --now firewalld
+            fi
+
+            # configure kubeadm
+            sudo cp /dev/stdin /etc/kubernetes/kubeadm_config.yaml <<< "
+            apiVersion: kubeadm.k8s.io/v1alpha1
+            kind: MasterConfiguration
+            api:
+              advertiseAddress: ${MASTER_IP}
+              bindPort: 443
+            etcd:
+              local:
+                dataDir: /var/lib/etcd
+                image:
+            kubernetesVersion: v${CONTROL_PLANE_VERSION}
+            token: ${TOKEN}
+            kubeProxy:
+              config:
+                clusterCIDR: ${POD_CIDR}
+            networking:
+              dnsDomain: ${CLUSTER_DNS_DOMAIN}
+              podSubnet: ${POD_CIDR}
+              serviceSubnet: ${SERVICE_CIDR}
+            "
+
+            # Create and set bridge-nf-call-iptables to 1 to pass the kubeadm preflight check.
+            # Workaround was found here:
+            # http://zeeshanali.com/sysadmin/fixed-sysctl-cannot-stat-procsysnetbridgebridge-nf-call-iptables/
+            if [[ $(sudo lsmod | grep br_netfilter -c) == 0 ]];then
+              sudo modprobe br_netfilter
+            fi
+
+            # Allowing swap may not be reliable:
+            # https://github.com/kubernetes/kubernetes/issues/53533
+            sudo swapoff -a
+          }
+
+          run_kubeadm()
+          {
+            sudo kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
+            for (( i = 0; i < 60; i++ )); do
+              sudo kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node "$(hostname)" machine="${MACHINE}" && break
+              sleep 1
+            done
+          }

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
@@ -4,7 +4,12 @@
           ARCH=amd64
 
           # install and configure docker
-          sudo yum install -y docker
+          if ! docker version >/dev/null 2>&1; then
+            sudo yum install -y docker
+          else
+            echo "Skipping installation of docker. Already installed."
+          fi
+
           sudo cp /dev/stdin /etc/sysconfig/docker <<< 'DOCKER_OPTS="--iptables=false --ip-masq=false"'
 
           # enable insecure image registry
@@ -44,11 +49,11 @@
             cidr=$1
 
             # range is bounded by network (-n) & broadcast (-b) addresses.
-            lo=$(ipcalc -n $cidr |cut -f2 -d=)
-            hi=$(ipcalc -b $cidr |cut -f2 -d=)
+            lo=$(ipcalc -n $cidr | cut -f2 -d=)
+            hi=$(ipcalc -b $cidr | cut -f2 -d=)
 
-            read a b c d <<< $(echo $lo |tr . ' ')
-            read e f g h <<< $(echo $hi |tr . ' ')
+            IFS='.' read a b c d <<< "$lo"
+            IFS='.' read e f g h <<< "$hi"
 
             eval "echo {$a..$e}.{$b..$f}.{$c..$g}.{$d..$h}"
           }

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_air_gapped_centos_7.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
@@ -1,0 +1,58 @@
+          set -e
+          set -x
+          (
+          ARCH=amd64
+
+          ${FUNCTIONS}
+
+          # Need to have common_functions sourced first!
+          if [[ -z "${MASTER_IP}" ]];then
+            echo >&2 "Cannot continue. \$MASTER_IP is not set."
+          fi
+
+          if [[ -z "${CONTROL_PLANE_VERSION}" ]];then
+            echo >&2 "Cannot continue. \$CONTROL_PLANE_VERSION is not set."
+          fi
+
+          if [[ -z "${TOKEN}" ]];then
+            echo >&2 "Cannot continue. \$TOKEN is not set."
+          fi
+
+          if [[ -z "${POD_CIDR}" ]];then
+            echo >&2 "Cannot continue. \$POD_CIDR is not set."
+          fi
+
+          if [[ -z "${CLUSTER_DNS_DOMAIN}" ]];then
+            echo >&2 "Cannot continue. \$CLUSTER_DNS_DOMAIN is not set."
+          fi
+
+          if [[ -z "${SERVICE_CIDR}" ]];then
+            echo >&2 "Cannot continue. \$SERVICE_CIDR is not set."
+          fi
+
+          CLUSTER_DNS_SERVER="$(prips "${SERVICE_CIDR}")"
+          export CLUSTER_DNS_SERVER
+
+          if install_docker; then
+            if install_k8s; then
+              if configure_kubelet; then
+                if configure_kubeadm; then
+                  if run_kubeadm; then
+                    echo "Done..."
+                  else
+                    exit 80
+                  fi
+                else
+                  exit 81
+                fi
+              else
+                exit 82
+              fi
+            else
+              exit 83
+            fi
+          else
+            exit 84
+          fi
+
+          ) 2>&1 | sudo tee /var/log/startup.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
@@ -33,25 +33,30 @@
           CLUSTER_DNS_SERVER="$(prips "${SERVICE_CIDR}")"
           export CLUSTER_DNS_SERVER
 
-          if install_docker; then
-            if install_k8s; then
-              if configure_kubelet; then
-                if configure_kubeadm; then
-                  if run_kubeadm; then
-                    echo "Done..."
-                  else
-                    exit 80
-                  fi
-                else
-                  exit 81
-                fi
-              else
-                exit 82
-              fi
-            else
-              exit 83
-            fi
+          if ! install_docker; then
+            echo >&2 "Error installing docker components..."
+            exit 80
+          fi
+
+          if ! install_k8s; then
+            echo >&2 "Error installing Kubernetes components..."
+            exit 81
+          fi
+
+          if ! configure_kubelet; then
+            echo >&2 "Error configuring Kubernetes components..."
+            exit 82
+          fi
+
+          if ! configure_kubeadm; then
+            echo >&2 "Error configuring kubeadm componenets..."
+            exit 83
+          fi
+
+          if run_kubeadm_master; then
+            echo "Done..."
           else
+            echo >&2 "Erroring occurred during Kubeadm for master k8s runtime."
             exit 84
           fi
 

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_aws_centos_7.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (
@@ -56,7 +57,7 @@
           if run_kubeadm_master; then
             echo "Done..."
           else
-            echo >&2 "Erroring occurred during Kubeadm for master k8s runtime."
+            echo >&2 "Error occurred during Kubeadm for master k8s runtime."
             exit 84
           fi
 

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_bootstrap_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_teardown_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_teardown_centos_7.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_teardown_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_teardown_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_centos_7.template
@@ -1,9 +1,10 @@
+
           set -e
           set -x
           (
           sudo yum upgrade -y kubectl=${KUBELET_VERSION} --disableexcludes=kubernetes
           sudo yum upgrade -y kubeadm=${KUBELET_VERSION} --disableexcludes=kubernetes
           sudo yum upgrade -y kubelet=${KUBELET_VERSION} --disableexcludes=kubernetes
-          
+
           sudo systemctl restart kubelet
           ) 2>&1 | sudo tee /var/log/upgrade.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/master_upgrade_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (
@@ -5,7 +6,7 @@
 
           # Run in noninteractive mode to avoid erroring when a config file preexists.
           export DEBIAN_FRONTEND=noninteractive
-          
+
           sudo apt update -y
 
           # Our Debian packages have versions like "1.8.0-00" or "1.8.0-01". Do a prefix

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_air_gapped_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_air_gapped_centos_7.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (
@@ -33,7 +34,7 @@
           182.195.81.113 quay.io gcr.io k8s.gcr.io registry-1.docker.io docker.io
           '
 
-          sudo systemctl enable --now docker 
+          sudo systemctl enable --now docker
 
           # install k8s tools
           sudo yum install -y kubelet-${KUBELET_VERSION}

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_aws_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_aws_centos_7.template
@@ -1,6 +1,4 @@
-          ### TODO
-          ### NOT YET COMPLETE
-          ### NEEDS TO BE FINISHED
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_aws_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_aws_centos_7.template
@@ -1,0 +1,61 @@
+          ### TODO
+          ### NOT YET COMPLETE
+          ### NEEDS TO BE FINISHED
+          set -e
+          set -x
+          (
+          ARCH=amd64
+
+          ${FUNCTIONS}
+
+          # Need to have common_functions sourced first!
+          if [[ -z "${MASTER_IP}" ]];then
+            echo >&2 "Cannot continue. \$MASTER_IP is not set."
+          fi
+
+          if [[ -z "${CONTROL_PLANE_VERSION}" ]];then
+            echo >&2 "Cannot continue. \$CONTROL_PLANE_VERSION is not set."
+          fi
+
+          if [[ -z "${TOKEN}" ]];then
+            echo >&2 "Cannot continue. \$TOKEN is not set."
+          fi
+
+          if [[ -z "${POD_CIDR}" ]];then
+            echo >&2 "Cannot continue. \$POD_CIDR is not set."
+          fi
+
+          if [[ -z "${CLUSTER_DNS_DOMAIN}" ]];then
+            echo >&2 "Cannot continue. \$CLUSTER_DNS_DOMAIN is not set."
+          fi
+
+          if [[ -z "${SERVICE_CIDR}" ]];then
+            echo >&2 "Cannot continue. \$SERVICE_CIDR is not set."
+          fi
+
+          CLUSTER_DNS_SERVER="$(prips "${SERVICE_CIDR}")"
+          export CLUSTER_DNS_SERVER
+
+          if install_docker; then
+            if install_k8s; then
+              if configure_kubelet; then
+                if configure_kubeadm; then
+                  if run_kubeadm; then
+                    echo "Done..."
+                  else
+                    exit 80
+                  fi
+                else
+                  exit 81
+                fi
+              else
+                exit 82
+              fi
+            else
+              exit 83
+            fi
+          else
+            exit 84
+          fi
+
+          ) 2>&1 | sudo tee /var/log/startup.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_bootstrap_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_centos_7.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_teardown_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_centos_7.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_centos_7.template
@@ -1,10 +1,11 @@
+
           set -e
           set -x
           (
           sudo yum upgrade -y kubectl=${KUBELET_VERSION} --disableexcludes=kubernetes
           sudo yum upgrade -y kubeadm=${KUBELET_VERSION} --disableexcludes=kubernetes
           sudo yum upgrade -y kubelet=${KUBELET_VERSION} --disableexcludes=kubernetes
-          
+
           sudo kubeadm upgrade node config --kubelet-version $(kubelet --version | cut -d ' ' -f 2)
           sudo systemctl restart kubelet
           ) 2>&1 | sudo tee /var/log/upgrade.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_ubuntu_16.04.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/node_upgrade_ubuntu_16.04.template
@@ -1,3 +1,4 @@
+
           set -e
           set -x
           (
@@ -5,7 +6,7 @@
 
           # Run in noninteractive mode to avoid erroring when a config file preexists.
           export DEBIAN_FRONTEND=noninteractive
-          
+
           sudo apt update -y
 
           # Our Debian packages have versions like "1.8.0-00" or "1.8.0-01". Do a prefix
@@ -23,10 +24,10 @@
           KUBELET=$(getversion kubelet ${KUBELET_VERSION}-)
           KUBECTL=$(getversion kubectl ${KUBELET_VERSION}-)
           KUBEADM=$(getversion kubeadm ${KUBELET_VERSION}-)
-         
+
           # upgrade kubelet last, so that dependencies don't overwrite the patch version
           sudo -E apt upgrade -y --allow-downgrades kubectl=${KUBECTL}
-          sudo -E apt upgrade -y --allow-downgrades kubeadm=${KUBEADM}  
+          sudo -E apt upgrade -y --allow-downgrades kubeadm=${KUBEADM}
           sudo -E apt upgrade -y --allow-downgrades kubelet=${KUBELET}
           # curl kubeadm to make sure it matches the desired version
           sudo curl -o /usr/bin/kubeadm -sSL https://dl.k8s.io/release/v${KUBELET_VERSION}/bin/linux/amd64/kubeadm

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -42,7 +42,8 @@ generate_yaml()
 {
   local bootstrap_dir machine_template_file machine_generated_file cluster_template_file
   local cluster_generated_file providercomponent_template_file providercomponent_generated_file
-  local master_upgrade_script master_teardown_script node_upgrade_script node_teardown_script
+  local MASTER_UPGRADE_SCRIPT MASTER_TEARDOWN_SCRIPT NODE_UPGRADE_SCRIPT NODE_TEARDOWN_SCRIPT
+  local MASTER_BOOTSTRAP_SCRIPT NODE_BOOTSTRAP_SCRIPT
 
   if ! mkdir -p "${OUTPUT_DIR}" 2>/dev/null; then
     echo >&2 "Unable to mkdir $OUTPUT_DIR"

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -4,118 +4,208 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# All configuration is done using environment variables.
-if [ "$#" -ne 0 ]; then
-    echo "Illegal number of parameters"
-fi
+inject_functions()
+{
+  local FUNCTIONS tmpl
 
-OUTPUT_DIR=out
-mkdir -p ${OUTPUT_DIR}
+  FUNCTIONS=$(< "$bootstrap_dir/common_functions.template")
+  tmpl=$1
 
-BOOTSTRAP_DIR=bootstrap_scripts
+  export FUNCTIONS
 
-OS_TYPE=${OS_TYPE:-ubuntu}
+  [[ -z "${tmpl}" ]] && \
+    {
+      echo >&2 "Usage: preprocess_template(): caller must provide template to process."
+      return 45
+    }
 
-# --- MACHINES ---
-MACHINE_TEMPLATE_FILE=machines.yaml.template
-MACHINE_GENERATED_FILE=${OUTPUT_DIR}/machines.yaml
+  # shellcheck disable=SC2016
+  envsubst '${FUNCTIONS}' < "$tmpl"
+}
 
+runpath()
+{
+  pushd . > /dev/null
+  SCRIPT_PATH="${BASH_SOURCE[0]}"
+  if ([ -h "${SCRIPT_PATH}" ]); then
+    while([ -h "${SCRIPT_PATH}" ]); do
+      cd "$(dirname "$SCRIPT_PATH")";
+      SCRIPT_PATH=$(readlink "${SCRIPT_PATH}");
+    done
+  fi
+  cd "$(dirname "${SCRIPT_PATH}")" > /dev/null
+  pwd
+  popd  > /dev/null
+}
 
-# --- CLUSTERS ---
-CLUSTER_TEMPLATE_FILE=cluster.yaml.template
-CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
+generate_yaml()
+{
+  local bootstrap_dir machine_template_file machine_generated_file cluster_template_file
+  local cluster_generated_file providercomponent_template_file providercomponent_generated_file
+  local master_upgrade_script master_teardown_script node_upgrade_script node_teardown_script
 
-# --- PROVIDER_CONFIG ---
-PROVIDERCOMPONENT_TEMPLATE_FILE=provider-components.yaml.template
-PROVIDERCOMPONENT_GENERATED_FILE=${OUTPUT_DIR}/provider-components.yaml
+  if ! mkdir -p "${OUTPUT_DIR}" 2>/dev/null; then
+    echo >&2 "Unable to mkdir $OUTPUT_DIR"
+    return 12
+  fi
 
-if [ $OS_TYPE == "ubuntu" ]; then
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_BOOTSTRAP=${BOOTSTRAP_DIR}/master_bootstrap_ubuntu_16.04.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_BOOTSTRAP=${BOOTSTRAP_DIR}/node_bootstrap_ubuntu_16.04.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_TEARDOWN=${BOOTSTRAP_DIR}/master_teardown_ubuntu_16.04.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_TEARDOWN=${BOOTSTRAP_DIR}/node_teardown_ubuntu_16.04.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_UPGRADE=${BOOTSTRAP_DIR}/master_upgrade_ubuntu_16.04.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_UPGRADE=${BOOTSTRAP_DIR}/node_upgrade_ubuntu_16.04.template
-else 
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_BOOTSTRAP=${BOOTSTRAP_DIR}/master_bootstrap_air_gapped_centos_7.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_BOOTSTRAP=${BOOTSTRAP_DIR}/node_bootstrap_air_gapped_centos_7.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_TEARDOWN=${BOOTSTRAP_DIR}/master_teardown_centos_7.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_TEARDOWN=${BOOTSTRAP_DIR}/node_teardown_centos_7.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_UPGRADE=${BOOTSTRAP_DIR}/master_upgrade_centos_7.template
-    PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_UPGRADE=${BOOTSTRAP_DIR}/node_upgrade_centos_7.template
-fi
+  bootstrap_dir=bootstrap_scripts
 
-OVERWRITE=0
+  # --- MACHINES ---
+  machine_template_file="$BASEDIR/machines.yaml.template"
+  machine_generated_file=${OUTPUT_DIR}/machines.yaml
 
-SCRIPT=$(basename $0)
-while test $# -gt 0; do
-        case "$1" in
-          -h|--help)
-            echo "$SCRIPT - generates input yaml files for Cluster API on openstack"
-            echo " "
-            echo "$SCRIPT [options]"
-            echo " "
-            echo "options:"
-            echo "-h, --help                show brief help"
-            echo "-f, --force-overwrite     if file to be generated already exists, force script to overwrite it"
-            exit 0
-            ;;
-          -f)
-            OVERWRITE=1
-            shift
-            ;;
-          --force-overwrite)
-            OVERWRITE=1
-            shift
-            ;;
-          *)
-            break
-            ;;
-        esac
-done
+  # --- CLUSTERS ---
+  cluster_template_file="$BASEDIR/cluster.yaml.template"
+  cluster_generated_file=${OUTPUT_DIR}/cluster.yaml
 
-if [ $OVERWRITE -ne 1 ] && [ -f $PROVIDERCOMPONENT_GENERATED_FILE ]; then
-  echo "File $PROVIDERCOMPONENT_GENERATED_FILE already exists. Delete it manually before running this script."
-  exit 1
-fi
+  # --- PROVIDER_CONFIG ---
+  providercomponent_template_file="$BASEDIR/provider-components.yaml.template"
+  providercomponent_generated_file=${OUTPUT_DIR}/provider-components.yaml
 
-# TODO Fill out the generation pieces as we need them.
+  if [[ $OVERWRITE -ne 1 ]] && [[ -f $providercomponent_generated_file ]]; then
+    echo >&1 "File $providercomponent_generated_file already exists. Delete it manually before running this script."
+    return 25
+  fi
 
-if [ -z ${CLUSTER_PRIVATE_KEY+x} ]; then
-    echo "Please generate a valid base64 encoded cluster private key and export the key file contents to CLUSTER_PRIVATE_KEY."
-    exit 1
-fi
+  # This sorely needs optimization. The file naming convention and usage here is not scalable.
+  if [[ "${OS_TYPE}" == "ubuntu" ]]; then
+    MASTER_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/master_bootstrap_ubuntu_16.04.template)"
+    MASTER_TEARDOWN_SCRIPT="$(< ${bootstrap_dir}/master_teardown_ubuntu_16.04.template)"
+    MASTER_UPGRADE_SCRIPT="$(< ${bootstrap_dir}/master_upgrade_ubuntu_16.04.template)"
 
-if [ -z ${CLUSTER_PASSPHRASE+x} ]; then
-    echo "using empty cluster pass phrase to private key"
-    CLUSTER_PASSPHRASE='""'
-fi
+    NODE_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/node_bootstrap_ubuntu_16.04.template)"
+    NODE_TEARDOWN_SCRIPT="$(< ${bootstrap_dir}/node_teardown_ubuntu_16.04.template)"
+    NODE_UPGRADE_SCRIPT="$(< ${bootstrap_dir}/node_upgrade_ubuntu_16.04.template)"
+  else
+    if [[ ${SDS_CASE} == 0 ]]; then
+      MASTER_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/master_bootstrap_aws_centos_7.template)"
 
-cat $PROVIDERCOMPONENT_TEMPLATE_FILE \
-  | sed -e "s/\$CLUSTER_PRIVATE_KEY/$CLUSTER_PRIVATE_KEY/" \
-  | sed -e "s/\$CLUSTER_PASSPHRASE/$CLUSTER_PASSPHRASE/" \
-  | sed -e "/\$MASTER_BOOTSTRAP_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_BOOTSTRAP" \
-  | sed -e "/\$MASTER_BOOTSTRAP_SCRIPT/d" \
-  | sed -e "/\$NODE_BOOTSTRAP_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_BOOTSTRAP" \
-  | sed -e "/\$NODE_BOOTSTRAP_SCRIPT/d" \
-  | sed -e "/\$MASTER_TEARDOWN_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_TEARDOWN" \
-  | sed -e "/\$MASTER_TEARDOWN_SCRIPT/d" \
-  | sed -e "/\$NODE_TEARDOWN_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_TEARDOWN" \
-  | sed -e "/\$NODE_TEARDOWN_SCRIPT/d" \
-  | sed -e "/\$MASTER_UPGRADE_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_MASTER_UPGRADE" \
-  | sed -e "/\$MASTER_UPGRADE_SCRIPT/d" \
-  | sed -e "/\$NODE_UPGRADE_SCRIPT/r $PROVIDERCOMPONENT_TEMPLATE_FILE_NODE_UPGRADE" \
-  | sed -e "/\$NODE_UPGRADE_SCRIPT/d" \
-  > $PROVIDERCOMPONENT_GENERATED_FILE
-echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE"
+      NODE_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/node_bootstrap_aws_centos_7.template)"
+    else
+      MASTER_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/master_bootstrap_air_gapped_centos_7.template)"
 
-cat $MACHINE_TEMPLATE_FILE \
-  > $MACHINE_GENERATED_FILE
-echo "Done generating $MACHINE_GENERATED_FILE"
+      NODE_BOOTSTRAP_SCRIPT="$(< ${bootstrap_dir}/node_bootstrap_air_gapped_centos_7.template)"
+    fi
 
-cat $CLUSTER_TEMPLATE_FILE \
-  > $CLUSTER_GENERATED_FILE
-echo "Done generating $CLUSTER_GENERATED_FILE"
+    MASTER_TEARDOWN_SCRIPT="$(< ${bootstrap_dir}/master_teardown_centos_7.template)"
+    MASTER_UPGRADE_SCRIPT="$(< ${bootstrap_dir}/master_upgrade_centos_7.template)"
 
-echo "You will still need to _edit_ the cluster.yaml and machines.yaml! See the README.md for details."
+    NODE_TEARDOWN_SCRIPT="$(< ${bootstrap_dir}/node_teardown_centos_7.template)"
+    NODE_UPGRADE_SCRIPT="$(< ${bootstrap_dir}/node_upgrade_centos_7.template)"
+  fi
 
+  # prepend common functions to template script
+  FUNCTIONS=$(< "$bootstrap_dir/common_functions.template")
+
+  export CLUSTER_PRIVATE_KEY CLUSTER_PASSPHRASE MASTER_BOOTSTRAP_SCRIPT \
+         NODE_BOOTSTRAP_SCRIPT MASTER_TEARDOWN_SCRIPT NODE_TEARDOWN_SCRIPT MASTER_UPGRADE_SCRIPT \
+         NODE_UPGRADE_SCRIPT FUNCTIONS OS_TYPE KUBELET_VERSION
+
+  # shellcheck disable=SC2016
+  envsubst '$CLUSTER_PRIVATE_KEY $CLUSTER_PASSPHRASE $MASTER_BOOTSTRAP_SCRIPT
+            $NODE_BOOTSTRAP_SCRIPT  $MASTER_TEARDOWN_SCRIPT $NODE_TEARDOWN_SCRIPT
+            $MASTER_UPGRADE_SCRIPT $NODE_UPGRADE_SCRIPT $KUBELET_VERSION $OS_TYPE' \
+           < "$providercomponent_template_file" > "$providercomponent_generated_file-tmp"
+
+  if inject_functions "$providercomponent_generated_file-tmp" > "$providercomponent_generated_file"; then
+    rm "$providercomponent_generated_file-tmp" 2>/dev/null
+  fi
+
+  echo "Done generating $providercomponent_generated_file"
+
+  cat "$machine_template_file" \
+    > "$machine_generated_file"
+  echo "Done generating $machine_generated_file"
+
+  cat "$cluster_template_file" \
+    > "$cluster_generated_file"
+  echo "Done generating $cluster_generated_file"
+
+  echo "You will still need to _edit_ the cluster.yaml and machines.yaml manifests! See the README.md for details."
+}
+
+main()
+{
+  SCRIPT=$(basename "$0")
+  OS_TYPE=${OS_TYPE:-ubuntu}
+  BASEDIR="$(runpath)"
+  OUTPUT_DIR="$BASEDIR/out"
+  KUBELET_VERSION=${KUBELET_VERSION:-1.10.6}
+  OVERWRITE=0
+  SDS_CASE=${SDS_CASE:-0}
+
+  while test $# -gt 0; do
+    case "$1" in
+      -h|--help)
+  # shellcheck disable=SC2140
+        echo """
+  $SCRIPT - generates input yaml files for Cluster API on openstack. Some environment
+        variables are needed set for $SCRIPT to properly function:
+
+        CLUSTER_PRIVATE_KEY   : base64 encoded private key used when make_cluster was run.
+        OS_TYPE               : One of "ubuntu" or "centos" -- defaults to "ubuntu"
+        CLUSTER_PASSPHRASE    : Only used if CLUSTER_PRIVATE_KEY was generated using a passphrase.
+        SDS_CASE              : 0 or 1 -- use 0 if creating a cluster in AWS or MaaS. Use 1 if
+                                creating a cluster in SDS Cloud -- defaults to 0.
+        KUBELET_VERSION       : e.g. 1.10.6 -- do not prepend a 'v' in front of it -- currently defaults to 1.10.6
+
+  $SCRIPT [options]
+
+  options:
+  -h, --help                show brief help
+  -f, --force-overwrite     if file to be generated already exists, force script to overwrite it
+
+  Completed manifests are placed in '$OUTPUT_DIR'
+
+        """
+        exit 0
+        ;;
+      -f|--force-overwrite)
+        OVERWRITE=1
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  # TODO Fill out the generation pieces as we need them.
+
+  if [[ -z ${CLUSTER_PRIVATE_KEY+x} ]]; then
+      echo "Please generate a valid base64 encoded cluster private key and export the key file contents to CLUSTER_PRIVATE_KEY."
+      exit 1
+  fi
+
+  if [[ -z "${CLUSTER_PASSPHRASE+x}" ]]; then
+      echo "Using empty cluster pass phrase to private key"
+      CLUSTER_PASSPHRASE='""'
+  fi
+
+  if [[ "${OS_TYPE}" =~ (centos|ubuntu) ]]; then
+    echo "OS Type set for valid type: $OS_TYPE."
+  else
+    echo >&2 "Invalid parameter for \$OS_TYPE: '$OS_TYPE'. Must be either 'ubuntu' or 'centos'"
+    exit 15
+  fi
+
+  if [[ "${SDS_CASE}" =~ [01] ]]; then
+    case ${SDS_CASE} in
+      0) echo "Creating templates for non-SDS Cloud environment.";;
+      1) echo "Creating templates for SDS Cloud environment.";;
+      *) echo "Invalid option: for SDS_CASE: ${SDS_CASE}";
+        exit 30
+      ;;
+    esac
+  else
+    echo >&2 "Invalid parameter for \$SDS_CASE: '$SDS_CASE'. Must be either '1' or '0'."
+    exit 20
+  fi
+
+  if ! generate_yaml; then
+    exit $?
+  fi
+}
+
+main "$@"

--- a/clusterctl/examples/ssh/generate-yaml.sh
+++ b/clusterctl/examples/ssh/generate-yaml.sh
@@ -114,12 +114,10 @@ generate_yaml()
 
   echo "Done generating $providercomponent_generated_file"
 
-  cat "$machine_template_file" \
-    > "$machine_generated_file"
+  envsubst < "$machine_template_file" > "$machine_generated_file"
   echo "Done generating $machine_generated_file"
 
-  cat "$cluster_template_file" \
-    > "$cluster_generated_file"
+  envsubst < "$cluster_template_file" > "$cluster_generated_file"
   echo "Done generating $cluster_generated_file"
 
   echo "You will still need to _edit_ the cluster.yaml and machines.yaml manifests! See the README.md for details."

--- a/clusterctl/examples/ssh/machines.yaml.template
+++ b/clusterctl/examples/ssh/machines.yaml.template
@@ -13,13 +13,13 @@ items:
             - Master
             - Etcd
           sshConfig:
-            username: ubuntu
+            username: $OS_TYPE
             host: 192.168.2.121
             port: 22
             secretName: cluster-private-key
       versions:
-        kubelet: 1.10.6
-        controlPlane: 1.10.6
+        kubelet: $KUBELET_VERSION
+        controlPlane: $KUBELET_VERSION
   # Nodes are defined as those items that do NOT have controlPlane
   # versions entry.
   - apiVersion: "cluster.k8s.io/v1alpha1"
@@ -34,9 +34,9 @@ items:
           roles:
             - Node
           sshConfig:
-            username: ubuntu
+            username: $OS_TYPE
             host: 192.168.2.187
             port: 22
             secretName: cluster-private-key
       versions:
-        kubelet: 1.10.6
+        kubelet: $KUBELET_VERSION


### PR DESCRIPTION
…replaced use of `sed` for `envsubst` which is safer and designed as a templating method in shell which is apropos for this project. Functionalized the generate script for better readability. Added functionality for `machine.yaml` to actually be processed so that `OS_TYPE` and `KUBELET_VERSION` are injected. Fixes some bugs. Created `common_functions.template` which will allow easier editing of templates vs having to potentially fix code in several templates.

There are a few things to note about this commit:

1. Though there is now a common functions template which gets injected in the new centos templates, it is not yet used in the other templates, yet.
2. The node bootstrap aws template is nothing more than a copy of the master template for now.
3. The steps currently scripted for the AWS centos implementation are not 100% correct yet. It's close, but not quite there yet.