### PR TITLE
*DO NOT MERGE* Never return ssh errors for testing purposes.

### DIFF
--- a/cloud/ssh/sshproviderclient.go
+++ b/cloud/ssh/sshproviderclient.go
@@ -83,7 +83,8 @@ func (s *sshProviderClient) ProcessCMD(cmd string) error {
 	defer session.Close()
 	defer connection.Close()
 
-	outputBytes, err := session.CombinedOutput(cmd)
+	//outputBytes, err := session.CombinedOutput(cmd)
+	outputBytes, _ := session.CombinedOutput(cmd)
 	glog.Infof("Command output = %s ", string(outputBytes[:]))
 
 	// Commented out to test theory that stdin, stdout, or stderr copy errors
@@ -104,7 +105,8 @@ func (s *sshProviderClient) ProcessCMDWithOutput(cmd string) ([]byte, error) {
 	defer session.Close()
 	defer connection.Close()
 
-	outputBytes, err := session.Output(cmd)
+	//outputBytes, err := session.Output(cmd)
+	outputBytes, _ := session.Output(cmd)
 
 	// Commented out to test theory that stdin, stdout, or stderr copy errors
 	// are preventing the annotation from being set. This then results in

--- a/cloud/ssh/sshproviderclient.go
+++ b/cloud/ssh/sshproviderclient.go
@@ -86,9 +86,13 @@ func (s *sshProviderClient) ProcessCMD(cmd string) error {
 	outputBytes, err := session.CombinedOutput(cmd)
 	glog.Infof("Command output = %s ", string(outputBytes[:]))
 
-	if err != nil {
-		return err
-	}
+	// Commented out to test theory that stdin, stdout, or stderr copy errors
+	// are preventing the annotation from being set. This then results in
+	// multiple simultaneous configuration scripts running. Unless the current
+	// scripts are really broken, we should normally never see ssh errors...
+	//if err != nil {
+	//	return err
+	//}
 	return nil
 }
 
@@ -102,7 +106,12 @@ func (s *sshProviderClient) ProcessCMDWithOutput(cmd string) ([]byte, error) {
 
 	outputBytes, err := session.Output(cmd)
 
-	return outputBytes, err
+	// Commented out to test theory that stdin, stdout, or stderr copy errors
+	// are preventing the annotation from being set. This then results in
+	// multiple simultaneous configuration scripts running. Unless the current
+	// scripts are really broken, we should normally never see ssh errors...
+	//return outputBytes, err
+	return outputBytes, nil
 }
 
 func (s *sshProviderClient) WriteFile(scriptLines string, remotePath string) error {
@@ -172,7 +181,7 @@ func GetBasicSession(s *sshProviderClient) (*ssh.Session, *ssh.Client, error) {
 	session, err := connection.NewSession()
 	if err != nil {
 		glog.Errorf("failed to create sesssion", err)
-		return nil, nil,fmt.Errorf("failed to create session: %v", err)
+		return nil, nil, fmt.Errorf("failed to create session: %v", err)
 	}
 
 	return session, connection, nil


### PR DESCRIPTION
This PR prevents ssh errors from being returned.

When the scripts (at least some of them) are run by hand they do not err out. This makes me think the errors we see when the actuator runs the script are erroneous and due to copy errors related to the golang ssh library when it attempts to copy stdin, stdout, or stderr.

This should be pushed up to a different tag and tested with a set of scripts which have worked when run by hand.