### PR TITLE
Use sysconfig cgroupfs

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -320,7 +320,7 @@
 
             if [[ -f /etc/sysconfig/kubelet ]]; then
               if ! grep -q 'driver=systemd' /etc/sysconfig/kubelet; then
-                sed -r -i.bak$(date +%Y%m%dT%H%M%s) 's/=(.*)/=--cgroup-driver=systemd \1/' /etc/sysconfig/kubelet
+                sed -r -i.bak-$(date +%Y%m%dT%H%M%s) 's/=(.*)/=--cgroup-driver=systemd \1/' /etc/sysconfig/kubelet
               else
                 echo "systemd cgroup driver already configured. Skipping"
               fi

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -318,6 +318,18 @@
 
             kubeadm upgrade node config --kubelet-version $(kubelet --version | cut -d ' ' -f 2)
 
+            if [[ -f /etc/sysconfig/kubelet ]]; then
+              if ! grep -q 'driver=systemd' /etc/sysconfig/kubelet; then
+                sed -r -i.bak$(date +%Y%m%dT%H%M%s) 's/=(.*)/=--cgroup-driver=systemd \1/' /etc/sysconfig/kubelet
+              else
+                echo "systemd cgroup driver already configured. Skipping"
+              fi
+            else
+              cat <<EOF > /etc/sysconfig/kubelet
+          KUBELET_EXTRA_ARGS=--cgroup-driver=systemd
+          EOF
+            fi
+
             systemctl daemon-reload
             systemctl restart kubelet
           }

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -320,7 +320,7 @@
 
             if [[ -f /etc/sysconfig/kubelet ]]; then
               if ! grep -q 'driver=systemd' /etc/sysconfig/kubelet; then
-                sed -r -i.bak-$(date +%Y%m%dT%H%M%s) 's/=(.*)/=--cgroup-driver=systemd \1/' /etc/sysconfig/kubelet
+                sed -r -i.bak-$(date +%Y%m%dT%H%M%S) 's/=(.*)/=--cgroup-driver=systemd \1/' /etc/sysconfig/kubelet
               else
                 echo "systemd cgroup driver already configured. Skipping"
               fi


### PR DESCRIPTION
according to the documentation, kubeadm seems to do the cgroupfs driver detection...
since we're upgrading, we're not using kubeadm in the scripts, so the detection fails. This tweak "manually" sets the correct cgroupfs driver to systemd.