### PR TITLE
Revert "Do not drain on teardown. (#154)"

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/aws/master_teardown.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/aws/master_teardown.template
@@ -5,9 +5,14 @@
           ARCH=amd64
           ${FUNCTIONS}
 
+          if ! drain; then
+            echo >&2 "Unable to drain and/or delete on $(hostname)..."
+            exit 68
+          fi
+
           if ! teardown; then
             echo >&2 "Teardown unsuccessful."
-            exit 1
+            exit 69
           fi
 
           echo "Done..."

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/aws/node_teardown.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/aws/node_teardown.template
@@ -7,7 +7,6 @@
 
           if ! teardown; then
             echo >&2 "Teardown unsuccessful."
-            exit 1
+            exit 68
           fi
-
           ) 2>&1 | sudo tee /var/log/teardown.log

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/master_teardown.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/master_teardown.template
@@ -4,6 +4,11 @@
 
           ${FUNCTIONS}
 
+          if ! drain; then
+            echo >&2 "Unable to drain and/or delete on $(hostname)..."
+            exit 1
+          fi
+
           if ! teardown; then
             echo >&2 "Teardown unsuccessful."
             exit 1


### PR DESCRIPTION
This reverts commit f189cb4dc04cfa05eae47d0e3502648482d6f593.

We need to delete the node.  Draining can take a while, we will drain and just allow for more time on delete in the cma-vmware.