### PR TITLE
Have to determine the default interface for the /etc/hosts entry. Als…

### DIFF
--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -217,7 +217,16 @@
               return 1
             fi
 
-            echo "$(ifconfig ens192 | grep -Po 'inet (\d{1,3}\.?)+' | awk '{print $2}') $(hostname)" >> /etc/hosts
+            if=$(netstat -rn | grep -P '^0.0.0.0 | awk '{print $8}')
+
+            if [[ -z "$if" ]]; then
+              echo >&2 "Unable to determine default network interface for /etc/hosts entry."
+              return 1
+            fi
+
+            # recommended to use `ip addr show` vs ifconfig as `ifconfig` is on the deprecation path
+            # and not installed by default.
+            echo "$(ip addr show "$if" | grep -Po 'inet (\d{1,3}\.?)+' | awk '{print $2}') $(hostname)" >> /etc/hosts
             echo "127.0.0.1 registry-1.docker.io gcr.io k8s.gcr.io quay.io" >> /etc/hosts
             echo -e "182.193.17.192 sds.redii.net\n" >> /etc/hosts
           }

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -217,7 +217,7 @@
               return 1
             fi
 
-            if=$(netstat -rn | grep -P '^0.0.0.0 | awk '{print $8}')
+            if=$(ip route list | grep default | awk '{print $5}')
 
             if [[ -z "$if" ]]; then
               echo >&2 "Unable to determine default network interface for /etc/hosts entry."

--- a/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
+++ b/clusterctl/examples/ssh/bootstrap_scripts/centos-7.4/sds/common_functions.template
@@ -224,7 +224,11 @@
               return 1
             fi
 
-            # recommended to use `ip addr show` vs ifconfig as `ifconfig` is on the deprecation path
+            # In order for CoreDNS to properly function, /etc/hosts must have an entry for its hostname
+            # especially if DNS is not be configurated. CoreDNS vx.y.z fails to start if it can not
+            # resolve its hostname.
+
+            # Recommended to use `ip addr show` vs ifconfig as `ifconfig` is on the deprecation path
             # and not installed by default.
             echo "$(ip addr show "$if" | grep -Po 'inet (\d{1,3}\.?)+' | awk '{print $2}') $(hostname)" >> /etc/hosts
             echo "127.0.0.1 registry-1.docker.io gcr.io k8s.gcr.io quay.io" >> /etc/hosts


### PR DESCRIPTION
…o switch from using ifconfig to `ip addr show` since we cannot assume ifconfig will be installed as it is being deprecated.